### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,9 @@ name: test
 
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/arrow2nd/shiny-poems/security/code-scanning/1](https://github.com/arrow2nd/shiny-poems/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only performs read operations (e.g., checking out code and installing dependencies), we will set `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary permissions to complete the tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
