### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   vrt:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/arrow2nd/shiny-poems/security/code-scanning/4](https://github.com/arrow2nd/shiny-poems/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient for most operations, and no write permissions are needed. The `permissions` block can be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
