### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,6 +6,10 @@ on:
     # 日本時間の深夜0時
     - cron: "0 15 * * *"
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/arrow2nd/shiny-poems/security/code-scanning/2](https://github.com/arrow2nd/shiny-poems/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Since the workflow primarily reads repository contents and creates pull requests, the permissions can be limited to `contents: read` and `pull-requests: write`. This ensures that the `GITHUB_TOKEN` has only the necessary access to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
