### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,5 +1,8 @@
 name: e2e
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/arrow2nd/shiny-poems/security/code-scanning/3](https://github.com/arrow2nd/shiny-poems/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- `contents: read` is required for the `actions/checkout` step to read the repository contents.
- No other steps in the workflow appear to require write permissions, so additional permissions are unnecessary.

The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
